### PR TITLE
[Example] Add Chemistry Task from Global-MMLU Dataset

### DIFF
--- a/lm_eval/tasks/science/basic_knowledge/chemistry.yaml
+++ b/lm_eval/tasks/science/basic_knowledge/chemistry.yaml
@@ -19,11 +19,11 @@ filter_list:
   - name: "xml-extract"
     filter:
       - function: "regex"
-        regex_pattern: "<answer>([A-D])</answer>"
+        regex_pattern: "<answer>(.*?)</answer>" # to capture responses like <answer>A\\</answer>
         group_select: 0
         fallback: "[invalid]"
 generation_kwargs:
-  max_tokens: 1024
+  max_tokens: 4096
   until:
     - "</s>"
     - "Q:"
@@ -37,3 +37,4 @@ metric_list:
     higher_is_better: true
     ignore_case: true
     ignore_punctuation: true
+    ignore_numbers: true

--- a/lm_eval/tasks/science/basic_knowledge/chemistry.yaml
+++ b/lm_eval/tasks/science/basic_knowledge/chemistry.yaml
@@ -1,0 +1,39 @@
+dataset_path: CohereForAI/Global-MMLU
+dataset_name: en
+dataset_kwargs: null
+validation_split: dev
+test_split: test
+fewshot_split: dev
+process_docs: !function utils.process_college_chemistry
+doc_to_text: >
+  You are an expert in chemistry. The following are multiple choice questions about chemistry. Let's think step by step. Please wrap the final answer in XML tags: <answer>X</answer> (where X is A, B, C, or D)
+  Question: {{question.strip()}}
+  A: {{option_a}}
+  B: {{option_b}}
+  C: {{option_c}}
+  D: {{option_d}}
+  Answer:
+doc_to_target: answer
+task: cumstomized_chemistry_mc
+filter_list:
+  - name: "xml-extract"
+    filter:
+      - function: "regex"
+        regex_pattern: "<answer>([A-D])</answer>"
+        group_select: 0
+        fallback: "[invalid]"
+generation_kwargs:
+  max_tokens: 1024
+  until:
+    - "</s>"
+    - "Q:"
+    - "<|im_end|>"
+  do_sample: false
+  temperature: 0.0
+num_fewshot: 0
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true

--- a/lm_eval/tasks/science/basic_knowledge/utils.py
+++ b/lm_eval/tasks/science/basic_knowledge/utils.py
@@ -1,0 +1,3 @@
+def process_college_chemistry(dataset):
+    return dataset.filter(lambda x: x["subject"] == "college_chemistry")
+


### PR DESCRIPTION
## Description
This PR adds a new task for evaluating chemistry knowledge using the Global-MMLU dataset. The task presents multiple choice questions about college-level chemistry concepts.

### Task Details
- **Dataset**: Global-MMLU (CohereForAI/Global-MMLU)
- **Subject**: Basic Knowledge, Chemistry
- **Format**: Multiple choice (A/B/C/D) -- direct text output format
- **Evaluation**: Exact match metric

## Implementation
- Added new YAML configuration in `lm_eval/tasks/science/basic_knowledge/chemistry.yaml`
- Added a python file `lm_eval/tasks/science/basic_knowledge/utils.py` for customized process_docs function
- Uses XML tags for answer extraction

## Testing
1. Pull and install lm-eval-harness and switch to the current branch
2. For commercial API models such as openai and anthropic models, you will need to set the env vars in your machine first:
```bash
export OPENAI_API_KEY=your_openai_api_key
export ANTHROPIC_API_KEY=your_anthropic_api_key
```
4. Run test commands (limited to first 10 questions)
```bash
# if you have anthropic api key
lm_eval --model anthropic-chat-completions --model_args model=claude-3-5-sonnet-20240620 --tasks cumstomized_chemistry_mc --limit 10 --output output/anthropic-3.5 --apply_chat_template --log_samples
# if you have openai api key
lm_eval --model openai-chat-completions --model_args model=gpt-4o --tasks cumstomized_chemistry_mc --limit 10 --output output/openai-4o --apply_chat_template --log_samples
```
Eaxmple output:
<img width="988" alt="image" src="https://github.com/user-attachments/assets/66518422-df0a-40c3-96f4-8d162e438fa3" />

See full list of supported models [here](https://github.com/EleutherAI/lm-evaluation-harness?tab=readme-ov-file#model-apis-and-inference-servers).

