### PR TITLE
add more chem tasks

### DIFF
--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/ir_structure_elucidation.yaml
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/ir_structure_elucidation.yaml
@@ -1,0 +1,15 @@
+include: _default_multiple_choice_yaml
+dataset_path: deep-principle/science-chemistry
+dataset_name: IR_structure_elucidation
+test_split: test
+doc_to_text: >
+  You are a chemist assistant with expertise in molecular structure elucidation. {{Question}}
+  Please wrap the final answer in XML tags: <answer>X</answer> (where X is A, B, C, D or E)
+  A: {{Option_A}}
+  B: {{Option_B}}
+  C: {{Option_C}}
+  D: {{Option_D}}
+  E: {{Option_E}}
+  Answer:
+doc_to_target: Answer
+task: IR_structure_elucidation

--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/ms_peak_identification.yaml
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/ms_peak_identification.yaml
@@ -1,0 +1,11 @@
+include: _default_multiple_choice_yaml
+process_docs: !function utils.process_ms_peak_identification
+doc_to_text: >
+  You are an expert in experimental chemistry. The following are multiple choice questions about MS Peak Identification. Let's think step by step. Please wrap the final answer in XML tags: <answer>X</answer> (where X is A, B, C, or D)
+  Question: {{Question.strip()}}
+  A: {{Option_A}}
+  B: {{Option_B}}
+  C: {{Option_C}}
+  D: {{Option_D}}
+  Answer:
+task: science_chem_ms_peak_identification

--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/mw_to_formula.yaml
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/mw_to_formula.yaml
@@ -1,0 +1,31 @@
+dataset_path: deep-principle/science-chemistry
+dataset_name: mw2formula
+test_split: test
+doc_to_text: >
+  You are an expert Chemist. {{Question}}
+  Please wrap the final answer in XML tags: <answer>X</answer> (where X is Chemical formula like C2H6O)
+  Answer:
+doc_to_target: Answer
+task: science_chem_mw_to_formula
+filter_list:
+  - name: "xml-extract"
+    filter:
+      - function: "regex"
+        regex_pattern: "<answer>(.*?)</answer>"
+        group_select: 0
+        fallback: "[invalid]"
+generation_kwargs:
+  max_tokens: 4096
+  until:
+    - "</s>"
+    - "Q:"
+    - "<|im_end|>"
+  do_sample: false
+num_fewshot: 0
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    ignore_numbers: false

--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/nmr_structure_elucidation.yaml
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/nmr_structure_elucidation.yaml
@@ -1,5 +1,5 @@
 dataset_path: deep-principle/science-chemistry
-dataset_name: structure_elucidation
+dataset_name: NMR_structure_elucidation
 test_split: test
 
 doc_to_text: >
@@ -11,8 +11,8 @@ doc_to_text: >
   Example answer format:  
   <SMILES>CCN(CC)CC</SMILES>  
   Answer:
-doc_to_target: "{{Answer}}"
-task: molecular_structure_elucidation
+doc_to_target: Answer
+task: nmr_structure_elucidation
 process_results: !function utils.process_smiles
 filter_list:
   - name: "xml-extract"

--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/reaction_mechanism.yaml
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/reaction_mechanism.yaml
@@ -1,0 +1,11 @@
+include: _default_multiple_choice_yaml
+process_docs: !function utils.process_reaction_mechanism
+doc_to_text: >
+  You are an expert in experimental chemistry. The following are multiple choice questions about competing reactions and protecting groups. Let's think step by step. Please wrap the final answer in XML tags: <answer>X</answer> (where X is A, B, C, or D)
+  Question: {{Question.strip()}}
+  A: {{Option_A}}
+  B: {{Option_B}}
+  C: {{Option_C}}
+  D: {{Option_D}}
+  Answer:
+task: science_chem_reaction_mechanism

--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/redox_potential.yaml
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/redox_potential.yaml
@@ -1,0 +1,30 @@
+dataset_path: deep-principle/science-chemistry
+dataset_name: redox_potential
+test_split: test
+doc_to_text: >
+  {{Question}}
+  Please wrap the final answer in XML tags: <answer>X</answer> (where X is a float number.)
+  Answer:
+doc_to_target: Answer
+task: science_chem_redox_potential
+process_results: !function utils.eval_redox_potential
+filter_list:
+  - name: "xml-extract"
+    filter:
+      - function: "regex"
+        regex_pattern: "<answer>(.*?)</answer>"
+        group_select: 0
+        fallback: "[invalid]"
+generation_kwargs:
+  max_tokens: 4096
+  until:
+    - "</s>"
+    - "Q:"
+    - "<|im_end|>"
+  do_sample: false
+num_fewshot: 0
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+    

--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/tmc_properties.yaml
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/tmc_properties.yaml
@@ -1,0 +1,31 @@
+dataset_path: deep-principle/science-chemistry
+dataset_name: TMC_properties
+test_split: test
+doc_to_text: >
+  {{Question}}
+  Please wrap the final answer in XML tags: <answer>X</answer> (where X is [ox]/[spin])
+  Answer:
+doc_to_target: Answer
+task: science_chem_tmc_properties
+filter_list:
+  - name: "xml-extract"
+    filter:
+      - function: "regex"
+        regex_pattern: "<answer>(.*?)</answer>"
+        group_select: 0
+        fallback: "[invalid]"
+generation_kwargs:
+  max_tokens: 4096
+  until:
+    - "</s>"
+    - "Q:"
+    - "<|im_end|>"
+  do_sample: false
+num_fewshot: 0
+metric_list:
+  - metric: exact_match
+    aggregation: mean
+    higher_is_better: true
+    ignore_case: true
+    ignore_punctuation: true
+    ignore_numbers: false

--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/utils.py
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/utils.py
@@ -58,7 +58,7 @@ def eval_redox_potential(doc, results):
         return {"acc": 0.0}
 
     try:
-        response = float(response)
+        response = float(response[0])
         reference = float(reference)
         threshold = float(threshold)
         if abs(response - reference) <= threshold:

--- a/lm_eval/tasks/science/advanced_reasoning/chemistry/utils.py
+++ b/lm_eval/tasks/science/advanced_reasoning/chemistry/utils.py
@@ -15,6 +15,8 @@ process_retrosynthesis = partial(process_docs, task='Retrosynthesis')
 process_experimental_techniques = partial(process_docs, task='Experimental Techniques')
 process_molecular_property = partial(process_docs, task='Molecular Property')
 process_quantum_software_usage = partial(process_docs, task='Quantum Software Usage')
+process_ms_peak_identification = partial(process_docs, task='MS Peak Identification')
+process_reaction_mechanism = partial(process_docs, task='Reaction Mechanism')
 
 def process_smiles(doc, results):
     try:
@@ -46,3 +48,23 @@ def process_smiles(doc, results):
     tanimoto = DataStructs.TanimotoSimilarity(fp_pred, fp_ref)
 
     return {"acc": tanimoto}
+
+def eval_redox_potential(doc, results):
+    reference = doc.get("Answer", "")
+    response = results[0] if results and isinstance(results[0], list) else results
+    threshold = doc.get("threshold", "0.25")
+
+    if not response:
+        return {"acc": 0.0}
+
+    try:
+        response = float(response)
+        reference = float(reference)
+        threshold = float(threshold)
+        if abs(response - reference) <= threshold:
+            return {"acc": 1.0}
+        else:
+            return {"acc": 0.0}
+
+    except:
+        return {"acc": 0.0}

--- a/lm_eval/tasks/science/chemistry.yaml
+++ b/lm_eval/tasks/science/chemistry.yaml
@@ -5,4 +5,10 @@ task:
   - science_chem_experimental_techniques
   - science_chem_molecular_property
   - science_chem_quantum_software
-  - molecular_structure_elucidation
+  - science_chem_ms_peak_identification
+  - science_chem_reaction_mechanism
+  - nmr_structure_elucidation
+  - IR_structure_elucidation
+  - science_chem_tmc_properties
+  - science_chem_redox_potential
+  - science_chem_mw_to_formula


### PR DESCRIPTION
## Implementation Details

### Files Added/Modified
- lm_eval/tasks/science/advanced_reasoning/chemistry/ir_structure_elucidation.yaml
- lm_eval/tasks/science/advanced_reasoning/chemistry/ms_peak_identification.yaml
- lm_eval/tasks/science/advanced_reasoning/chemistry/mw_to_formula.yaml
- lm_eval/tasks/science/advanced_reasoning/chemistry/nmr_structure_elucidation.yaml (renamed from molecular_structure_elucidation.yaml)
- lm_eval/tasks/science/advanced_reasoning/chemistry/reaction_mechanism.yaml
- lm_eval/tasks/science/advanced_reasoning/chemistry/redox_potential.yaml
- lm_eval/tasks/science/advanced_reasoning/chemistry/tmc_properties.yaml
- lm_eval/tasks/science/advanced_reasoning/chemistry/utils.py
- lm_eval/tasks/science/chemistry.yaml

### Dataset Implementation
Data format: All tasks use the deep-principle/science-chemistry dataset with specific dataset names for each task
Number of examples: Tasks include 5-21 test examples each (based on test results showing effective sample sizes)
Evaluation metrics:
Tanimoto similarity for molecular structure tasks (using RDKit Morgan fingerprints)
Exact match for formula and property tasks (case-insensitive, punctuation-ignored)
Threshold-based accuracy for redox potential (within ±0.25V tolerance)

## Testing

### Test Command
```bash
lm_eval --model anthropic-chat-completions --model_args model=claude-3-5-sonnet-20240620 --tasks science_chemistry --apply_chat_template --output results/chem_sample.json --log_samples --limit 2
```

### Reproduction Steps
1. Install required dependencies: conda install -c conda-forge rdkit
2. Ensure access to the deep-principle/science-chemistry dataset
3. Run the test command above with your preferred model
4. Verify results match expected format and metrics

## Results
<img width="931" height="237" alt="image" src="https://github.com/user-attachments/assets/23925ce7-8aed-4c31-a88c-9c7100e9ff24" />

## Checklist
- [X] Test command provided and verified locally
- [X] Test results included (screenshots or output)
- [X] Relevant reviewers tagged
